### PR TITLE
Update schemas for emoji picker

### DIFF
--- a/build_files/scripts/gs-extensions/list.json
+++ b/build_files/scripts/gs-extensions/list.json
@@ -60,7 +60,8 @@
     },
     {
         "repo": "https://github.com/felipeftn/emoji-copy",
-        "asset": "emoji-copy@felipeftn.zip"
+        "asset": "emoji-copy@felipeftn.zip",
+        "schemas": "schemas"
     },
     {
         "repo": "https://github.com/komorebinator/borshevik-workspace-manager.git",


### PR DESCRIPTION
Adds `"schemas": "schemas"` to the `emoji-copy@felipeftn` entry in `build_files/scripts/gs-extensions/list.json` so the extension's GSettings schemas get compiled during the image build.

Cherry-picked from `experimental` (35ebc40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)